### PR TITLE
Fix/namespace

### DIFF
--- a/bin/kubedecode
+++ b/bin/kubedecode
@@ -20,7 +20,7 @@ fi
 SECRET="$1"
 
 if [[ -z "${2// }" ]]; then
-  NAMESPACE=$(kubectl config get-contexts --no-headers | tr -s ' ' | cut -d ' ' -f5)
+  NAMESPACE=$(kubectl config view --minify --output 'jsonpath={..namespace}')
   [ ! -z "$NAMESPACE" ] || NAMESPACE=$KUBENS
   echo "No namespace set, using default: ${NAMESPACE}"
 else

--- a/bin/kubedecode
+++ b/bin/kubedecode
@@ -21,7 +21,7 @@ SECRET="$1"
 
 if [[ -z "${2// }" ]]; then
   NAMESPACE=$(kubectl config get-contexts --no-headers | tr -s ' ' | cut -d ' ' -f5)
-  [ ! -z $NAMESPACE ] || NAMESPACE=$KUBENS
+  [ ! -z "$NAMESPACE" ] || NAMESPACE=$KUBENS
   echo "No namespace set, using default: ${NAMESPACE}"
 else
   NAMESPACE="$2"


### PR DESCRIPTION
The previous way to acquire the current namespace isn't working anymore:

```bash
❯ ./kubedecode myPrecious
./kubedecode: line 24: [: too many arguments
No namespace set, using default:
former: Smeagol 
actual: Gollum
```

I also added quotes to $NAMESPACE to comply with ShellCheck linting